### PR TITLE
Updated autograding tests to be more forgiving.

### DIFF
--- a/AutogradingTests/AutogradingTests.cs
+++ b/AutogradingTests/AutogradingTests.cs
@@ -1,4 +1,5 @@
-﻿using TechJobsConsoleAutograded6;
+﻿using System.Globalization;
+using TechJobsConsoleAutograded6;
 
 namespace AutogradingTests;
 
@@ -21,7 +22,8 @@ public class UnitTest1
         app.RunProgram();
 
         var output = writer.ToString();
-        Assert.AreEqual(text, output);
+        int stringComparison = String.Compare(text, output, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreSymbols);
+        Assert.AreEqual(stringComparison, 0);
     }
 
     [TestMethod]
@@ -40,7 +42,8 @@ public class UnitTest1
         app.RunProgram();
 
         var output = writer.ToString();
-        Assert.AreEqual(text, output);
+        int stringComparison = String.Compare(text, output, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreSymbols);
+        Assert.AreEqual(stringComparison, 0);
     }
 
     [TestMethod]
@@ -58,7 +61,8 @@ public class UnitTest1
         app.RunProgram();
 
         var output = writer.ToString();
-        Assert.AreEqual(text, output);
+        int stringComparison = String.Compare(text, output, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreSymbols);
+        Assert.AreEqual(stringComparison, 0);
     }
 
     [TestMethod]
@@ -76,7 +80,8 @@ public class UnitTest1
         app.RunProgram();
 
         var output = writer.ToString();
-        Assert.AreEqual(text, output);
+        int stringComparison = String.Compare(text, output, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreSymbols);
+        Assert.AreEqual(stringComparison, 0);
     }
 
 }


### PR DESCRIPTION
Updated the tests to ignore symbols and case to be more friendly to our learners. When I completed the exercise the tests were failing because I put a newline after writing the job description in TechJobs.PrintJobs which caused the tests to fail and was somewhat difficult to diagnose. I anticipate new programmers to experience at least a similar level of frustration when encountering this issue.